### PR TITLE
:truck: transfer repository to duck-dynasty

### DIFF
--- a/.github/workflows/rick-roll.yml
+++ b/.github/workflows/rick-roll.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types:
     - opened
-  pull_request:
+  pull_request_target:
     types:
     - opened
     - synchronize

--- a/.github/workflows/rick-roll.yml
+++ b/.github/workflows/rick-roll.yml
@@ -5,9 +5,6 @@ on:
     types:
     - opened
   pull_request_target:
-    types:
-    - opened
-    - synchronize
 
 jobs:
   roll:

--- a/.github/workflows/rick-roll.yml
+++ b/.github/workflows/rick-roll.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     types:
     - opened
+    - synchronize
 
 jobs:
   roll:

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ on:
   issues:
     types:
     - opened
-  pull_request:
+  pull_request_target:
     types:
     - opened
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ jobs:
   roll:
     runs-on: ubuntu-latest
     steps:
-    - uses: twentylemon/rick-roll-action@v1
+    - uses: duck-dynasty/rick-roll-action@v1
       with:
         chance: 5  # a 5% chance of including the gif
 ```

--- a/action.yml
+++ b/action.yml
@@ -23,5 +23,5 @@ runs:
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,
-            body: "![rick](https://user-images.githubusercontent.com/5175174/143780490-a2035c5d-e6de-4aa3-99d8-300e98ebd6af.gif)"
+            body: "![rick](https://user-images.githubusercontent.com/5175174/143781889-dec45cbf-baab-4d33-a9ce-91abc0390875.gif)"
           })


### PR DESCRIPTION
Made the repo in my own account first, then transferred here. Just updating the readme which has the example usage.